### PR TITLE
プレビューコマンドを省略できるようにした

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,26 +27,24 @@ ROXX-botはbackcheckのプレビュー環境を構築するbotです。
 1. URLのリンクを踏むとプレビュー環境を見ることができます。
 
 ### ユースケース
-事前に自分のプルリクエストのIDを確認します。
-
-例えば https://github.com/reno-shelter/backcheck_api/pull/1530 だったら `1530` がIDです。
 
 #### APIのみのプレビュー環境
-1. `@roxx-bot preview this FRONT_URL=https://reno-shelter-backcheck-api-pr-${ID}-backcheck-front.preview.backcheck.jp`
-1. `@roxx-bot preview front API_URL=https://reno-shelter-backcheck-api-pr-${ID}.preview.backcheck.jp`
+1. `@roxx-bot preview this`
+1. `@roxx-bot preview front`
 
 #### FRONTのみのプレビュー環境
-1. `@roxx-bot preview this API_URL=https://reno-shelter-backcheck-front-pr-${ID}-backcheck-api.preview.backcheck.jp`
-1. `@roxx-bot preview api FRONT_URL=https://reno-shelter-backcheck-front-pr-${ID}.preview.backcheck.jp`
+1. `@roxx-bot preview this`
+1. `@roxx-bot preview api`
 
 #### APIとFRONTの複合プレビュー環境
-1. API側のプルリクエストで以下をコメントし、
+1. APIとFRONTでそれぞれプルリクエストを作成する
+1. API側のプルリクエストでFRONTのURLをつけた状態でコメントする
 
-    `@roxx-bot preview this FRONT_URL=https://reno-shelter-backcheck-front-pr-${FRONT_ID}.preview.backcheck.jp`
+    `@roxx-bot preview this https://github.com/reno-shelter/backcheck_front/pull/XXXX`
 
-1. FRONT側のプルリクエストで以下をコメントする
+1. FRONT側のプルリクエストでAPIのURLをつけた状態でコメントする
 
-    `@roxx-bot preview this API_URL=https://reno-shelter-backcheck-api-pr-${API_ID}.preview.backcheck.jp`
+    `@roxx-bot preview this https://github.com/reno-shelter/backcheck_api/pull/XXXX`
 
 ## FAQ
 ### adminは？


### PR DESCRIPTION
see: https://github.com/reno-shelter/backcheck_front/pull/1832

@roxx-bot preview (this|api|front)
→そのPRからよしなに解釈して、FRONT_URLやAPI_URLを自動で保管

![image](https://user-images.githubusercontent.com/1287296/73909545-467a6a00-48f0-11ea-8e8a-d1dd6f7733b8.png)
![image](https://user-images.githubusercontent.com/1287296/73909551-4a0df100-48f0-11ea-8a7f-0ebdd3e462fa.png)


@roxx-bot preview (this|api|front) <githubのPRのURL>
→付与したPRのURLからよしなに解釈して、FRONT_URLやAPI_URLを自動で保管

![image](https://user-images.githubusercontent.com/1287296/73909564-51cd9580-48f0-11ea-84d8-7f46d55b8945.png)
![image](https://user-images.githubusercontent.com/1287296/73909574-57c37680-48f0-11ea-9795-62cdf344d1a6.png)
